### PR TITLE
increase sleep timeout to get transacation processed in a rinkeby network

### DIFF
--- a/scripts/deploy_lottery.py
+++ b/scripts/deploy_lottery.py
@@ -44,7 +44,7 @@ def end_lottery():
     tx.wait(1)
     ending_transaction = lottery.endLottery({"from": account})
     ending_transaction.wait(1)
-    time.sleep(60)
+    time.sleep(180)
     print(f"{lottery.recentWinner()} is the new winner!")
 
 

--- a/tests/test_lottery_integration.py
+++ b/tests/test_lottery_integration.py
@@ -19,6 +19,6 @@ def test_can_pick_winner():
     lottery.enter({"from": account, "value": lottery.getEntranceFee()})
     fund_with_link(lottery)
     lottery.endLottery({"from": account})
-    time.sleep(60)
+    time.sleep(180)
     assert lottery.recentWinner() == account
     assert lottery.balance() == 0


### PR DESCRIPTION
After running some tests i noticed that 180sec is a good fit for a rinkeby network.