### PR TITLE
Explicitly define address as payable

### DIFF
--- a/contracts/Lottery.sol
+++ b/contracts/Lottery.sol
@@ -43,7 +43,7 @@ contract Lottery is VRFConsumerBase, Ownable {
         // $50 minimum
         require(lottery_state == LOTTERY_STATE.OPEN);
         require(msg.value >= getEntranceFee(), "Not enough ETH!");
-        players.push(msg.sender);
+        players.push(payable(msg.sender));
     }
 
     function getEntranceFee() public view returns (uint256) {


### PR DESCRIPTION
Creates a payable sender address to be pushed to the players array. Prevents TypeError when pushing in newer versions of Solidity.

Solc version: 0.8.7
CompilerError: solc returned the following errors:
TypeError: Member "push" not found or not visible after argument-dependent lookup in address payable[] storage ref.